### PR TITLE
Remove level 1 headers from docs as it duplicates title frontmatter

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -6,8 +6,6 @@ weight = 0
     type = 'docs'
 +++
 
-# Developer Quick-Start
-
 Please make sure you have all the [prerequisites](prerequisites.md) covered first.
 Then you can deploy a complete, open-source, event-streaming stack on your local Kubernetes cluster (e.g. MiniKube, KIND) with a single command:
 

--- a/docs/accessing-services.md
+++ b/docs/accessing-services.md
@@ -3,8 +3,6 @@ title = 'Accessing Services'
 weight = 3
 +++
 
-# Accessing Services
-
 ## StreamsHub Console
 
 ### Ingress Access

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,8 +3,6 @@ title = 'Architecture'
 weight = 6
 +++
 
-# Architecture
-
 ## Two-Phase Deployment
 
 The event stack is deployed in two sequential phases:
@@ -17,9 +15,9 @@ Operators must be running to process these resources.
 
 This separation exists for three reasons:
 
-1. **CRD registration** — Kubernetes must register CRDs before it can accept custom resources of that type
-2. **Operator readiness** — operators must be running to reconcile their custom resources
-3. **Safe teardown** — during uninstall, operands are deleted first while operators are still alive to process finalizers
+1. CRD registration — Kubernetes must register CRDs before it can accept custom resources of that type
+2. Operator readiness — operators must be running to reconcile their custom resources
+3. Safe teardown — during uninstall, operands are deleted first while operators are still alive to process finalizers
 
 The install script uses `kubectl apply --server-side` for Phase 1 to handle large CRDs (such as those from the Prometheus Operator) that exceed the annotation size limit used by client-side apply.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,8 +3,6 @@ title = 'Installation'
 weight = 2
 +++
 
-# Installation
-
 ## Quick-Start Install
 
 Deploy the entire core stack with a single command:

--- a/docs/overlays/_index.md
+++ b/docs/overlays/_index.md
@@ -3,8 +3,6 @@ title = 'Overlays'
 weight = 4
 +++
 
-# Overlays
-
 The developer quick-start uses [Kustomize overlays](architecture.md) to provide optional extensions on top of the core stack. 
 Each overlay adds components that integrate with the base deployment.
 

--- a/docs/overlays/core.md
+++ b/docs/overlays/core.md
@@ -5,8 +5,6 @@ cpu_total = '3 CPU cores'
 memory_total = '4.5 GiB'
 +++
 
-# Core Overlay
-
 The core overlay is the default deployment. 
 It installs the base event-streaming stack without any optional extensions.
 

--- a/docs/overlays/developing.md
+++ b/docs/overlays/developing.md
@@ -3,8 +3,6 @@ title = 'Developing Overlays'
 weight = 100
 +++
 
-# Developing Overlays
-
 This page covers the requirements for adding or modifying overlays. 
 CI enforces various checks on the overlays automatically on every pull request.
 

--- a/docs/overlays/metrics.md
+++ b/docs/overlays/metrics.md
@@ -5,8 +5,6 @@ cpu_total = '3 CPU cores'
 memory_total = '5.5 GiB'
 +++
 
-# Metrics Overlay
-
 The metrics overlay extends the core stack with Prometheus-based monitoring.
 
 ## Quick-Start Install

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -3,8 +3,6 @@ title = 'Prerequisites'
 weight = 1
 +++
 
-# Prerequisites
-
 ## Required
 
 - **kubectl v1.27 or later** — the install scripts use Kustomize v5.0 features (the `labels` transformer) which require kubectl 1.27+.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,8 +3,6 @@ title = 'Troubleshooting'
 weight = 7
 +++
 
-# Troubleshooting
-
 ## Operator Not Becoming Ready
 
 If an operator deployment does not reach `Ready`/`Available` within the timeout:

--- a/docs/uninstallation.md
+++ b/docs/uninstallation.md
@@ -3,8 +3,6 @@ title = 'Uninstallation'
 weight = 5
 +++
 
-# Uninstallation
-
 ## Using the Uninstall Script
 
 The uninstall script provides safe teardown with shared-cluster awareness:


### PR DESCRIPTION
This PR removes all the level 1 headings from the docs and the `title` front-matter field already covers that. Leaving the headings in leads to duplicate heading when the docs are pulled into the main streamshub site.